### PR TITLE
test: add gmt offset to date creation in test

### DIFF
--- a/packages/horologist/src/components/DayNightIndicator/DayNightIndicator.test.ts
+++ b/packages/horologist/src/components/DayNightIndicator/DayNightIndicator.test.ts
@@ -13,7 +13,7 @@ describe('Day/Night Indicator', () => {
         },
     ];
     const id = 'test-id';
-    const date = new Date('2022/7/20 13:30:10');
+    const date = new Date('2022/7/20 13:30:10 GMT+03:00');
     let test: Watch;
 
     beforeAll(() => {


### PR DESCRIPTION
## 🔐 Closes

-

## 🚀 Changes

- adds gmt time offset to new date in day night indicator test

## ⛳️ Testing

- ran yarn test to ensure tests pass locally
