### PR TITLE
fix: remove date-fns-tz and use date prop instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "lint:fix": "yarn lint -- --fix",
         "prettier": "prettier ./ --check",
         "prettier:fix": "yarn prettier -- --write",
-        "format": "yarn prettier:fix && yarn lint:fix"
+        "format": "yarn prettier:fix && yarn lint:fix",
+        "reset": "rm -rf node_modules */**/node_modules yarn.lock && yarn"
     },
     "author": "Daniel Yuschick <daniel.yuschick@gmail.com>",
     "license": "UNLICENSED",

--- a/packages/horologist/esbuild.config.js
+++ b/packages/horologist/esbuild.config.js
@@ -3,6 +3,6 @@ require('esbuild').buildSync({
     bundle: true,
     minify: true,
     outdir: 'dist',
-    external: ['date-fns', 'date-fns-tz', 'suntimes', 'lunarphase-js'],
+    external: ['date-fns', 'suntimes', 'lunarphase-js'],
     format: 'esm',
 });

--- a/packages/horologist/package.json
+++ b/packages/horologist/package.json
@@ -59,7 +59,6 @@
         "typescript": "^4.7.4"
     },
     "dependencies": {
-        "date-fns-tz": "^1.3.6",
         "date-fns": "^2.28.0",
         "lunarphase-js": "^1.0.10",
         "suntimes": "^6.0.2"

--- a/packages/horologist/src/components/DayNightIndicator/DayNightIndicator.test.ts
+++ b/packages/horologist/src/components/DayNightIndicator/DayNightIndicator.test.ts
@@ -2,6 +2,8 @@ import content from '../../content';
 import { Watch } from '../Watch';
 
 describe('Day/Night Indicator', () => {
+    const date = new Date('2022/7/20 13:30:10');
+    const dateSubDial = new Date('2022/7/20 03:30:10');
     const dials = [
         {
             id: 'test',
@@ -10,17 +12,16 @@ describe('Day/Night Indicator', () => {
                     id: 'seconds',
                 },
             },
-            timezone: 'Europe/Helsinki',
+            date,
         },
     ];
     const id = 'test-id';
-    const date = new Date('2022/7/20 13:30:10 GMT+3:00');
     const rotateIncrement = 360 / 4;
     let test: Watch;
 
     beforeAll(() => {
         document.body.innerHTML = `<div id="${id}" /><div id="seconds" />`;
-        test = new Watch({ dials, dayNight: { id }, settings: { date } });
+        test = new Watch({ dials, dayNight: { id } });
     });
 
     it('should return a watch object with a dayNight property', () => {
@@ -40,21 +41,19 @@ describe('Day/Night Indicator', () => {
     });
 
     it('should return the correct rotational value when reversed', () => {
-        const date = new Date('2000/6/28 19:25:00');
-        const test = new Watch({ dials, dayNight: { id, reverse: true }, settings: { date } });
+        const test = new Watch({ dials, dayNight: { id, reverse: true } });
         const value = test.dayNight?.getRotationValue();
 
-        expect(value).toEqual(rotateIncrement * 3 * -1);
+        expect(value).toEqual(rotateIncrement * 2 * -1);
     });
 
     it('should return the correct rotational value with offset hours', () => {
-        const date = new Date('2000/6/28 10:25:00 GMT+3:00');
         const test = new Watch({ dials, dayNight: { id, offsetHours: true }, settings: { date } });
 
         const offsetIncrement = rotateIncrement / 6;
         const value = test.dayNight?.getRotationValue();
 
-        expect(value).toEqual(rotateIncrement + 4 * offsetIncrement);
+        expect(value).toEqual(rotateIncrement * 2 + offsetIncrement);
     });
 
     it('should return a value based on a dial target', () => {
@@ -65,19 +64,18 @@ describe('Day/Night Indicator', () => {
                 {
                     id: 'one',
                     hands: { seconds: { id: 'seconds-hand' } },
-                    timezone: 'Europe/Helsinki',
+                    date,
                 },
                 {
                     id: 'two',
                     hands: { seconds: { id: 'two-seconds-hand' } },
-                    timezone: 'America/Los_Angeles',
+                    date: new Date('2022/7/7 03:30:10'),
                 },
             ],
             dayNight: {
                 dial: 'two',
                 id,
             },
-            settings: { date },
         });
 
         test.start();
@@ -90,18 +88,17 @@ describe('Day/Night Indicator', () => {
                 {
                     id: 'one',
                     hands: { seconds: { id: 'seconds-hand' } },
-                    timezone: 'Europe/Helsinki',
+                    date,
                 },
                 {
                     id: 'two',
                     hands: { seconds: { id: 'two-seconds-hand' } },
-                    timezone: 'America/Los_Angeles',
+                    date: dateSubDial,
                 },
             ],
             dayNight: {
                 id,
             },
-            settings: { date },
         });
 
         test.start();

--- a/packages/horologist/src/components/Dial/Dial.ts
+++ b/packages/horologist/src/components/Dial/Dial.ts
@@ -1,5 +1,4 @@
 import { addSeconds, getHours, getMinutes, getSeconds } from 'date-fns';
-import DateFnsTz from 'date-fns-tz';
 
 import content from '../../content';
 import { rotate, setElementTransition } from '../../utils';
@@ -40,9 +39,7 @@ export class Dial implements DialClass {
         this.options = options;
         this.settings = {
             ...settings,
-            now: options.timezone
-                ? DateFnsTz.utcToZonedTime(settings.now, options.timezone)
-                : settings.now,
+            now: options.date || settings.now,
         };
         this.hands = {
             seconds: options.hands.seconds

--- a/packages/horologist/src/components/Dial/Dial.types.ts
+++ b/packages/horologist/src/components/Dial/Dial.types.ts
@@ -9,6 +9,7 @@ export interface DialClass {
 }
 
 export interface DialOptions {
+    date?: Date;
     format?: 12 | 24;
     hands: {
         seconds?: DialSecondsHand;
@@ -16,7 +17,6 @@ export interface DialOptions {
         hours?: DialHand & DialJumpHand;
     };
     id?: string;
-    timezone?: string;
 }
 
 export type DialSecondsHand = DialSecondsHandSweep | DialSecondsHandJump;

--- a/packages/horologist/src/components/Dial/README.md
+++ b/packages/horologist/src/components/Dial/README.md
@@ -17,6 +17,7 @@ timepieces.
 
 ```ts
 dials: [{
+    date?: date;
     format?: 12 | 24;
     hands: {
         seconds?: {
@@ -53,9 +54,17 @@ dials: [{
         }
     };
     id?: string;
-    timezone?: string;
 }]
 ```
+
+### `date`
+
+By default, the Dial will show the current system time. However, this can be adjusted by passing a
+`new Date()` with a specific time.
+
+| Props  | Required | Type | Default | Value(s) |
+| ------ | -------- | ---- | ------- | -------- |
+| `date` | No       | date | -       | -        |
 
 ### `format`
 
@@ -133,15 +142,6 @@ An ID to associate with each Dial for references between complications.
 | Props | Required | Type   | Default | Value(s) |
 | ----- | -------- | ------ | ------- | -------- |
 | `id`  | No       | string | -       | -        |
-
-### `timezone`
-
-By default, the Dial will show the current location's time. However, this can be adjusted by passing
-an IANA `timezone` string, like `Europe/Helsinki` to force the dial into a specific timezone.
-
-| Props      | Required | Type   | Default | Value(s)                                                                      |
-| ---------- | -------- | ------ | ------- | ----------------------------------------------------------------------------- |
-| `timezone` | No       | string | -       | [IANA timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) |
 
 ## Design Considerations
 

--- a/packages/horologist/src/components/Watch/Watch.ts
+++ b/packages/horologist/src/components/Watch/Watch.ts
@@ -1,5 +1,4 @@
 import { isSameDay, isSameHour, isSameMinute, isSameMonth } from 'date-fns';
-import DateFnzTz from 'date-fns-tz';
 import { Chronograph } from '../Chronograph';
 import { DateIndicator } from '../DateIndicator';
 
@@ -102,9 +101,7 @@ export class Watch implements Types.WatchClass {
                 if (this.repeater) this.repeater.now = this.settings.now;
 
                 this.dials?.forEach((dial) => {
-                    dial.settings.now = dial.options.timezone
-                        ? DateFnzTz.utcToZonedTime(this.settings.now, dial.options.timezone)
-                        : this.settings.now;
+                    dial.settings.now = dial.options.date || this.settings.now;
                     if (dial.options.hands.minutes || dial.options.hands.hours) {
                         dial.rotateHands({ minutes: true, hours: true });
                     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1813,11 +1813,6 @@ data-urls@^3.0.1:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-date-fns-tz@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.6.tgz#4195a58a2f86eda55ea69fb477f3ed8a6e2188ac"
-  integrity sha512-C8q7mErvG4INw1ZwAFmPlGjEo5Sv4udjKVbTc03zpP9cu6cp5AemFzKhz0V68LGcWEtX5mJudzzg3G04emIxLA==
-
 date-fns@*, date-fns@^2.28.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.1.tgz#9667c2615525e552b5135a3116b95b1961456e60"


### PR DESCRIPTION
## 🔐 Closes

-

## 🚀 Changes

- removes date-fns-tz due to unreliability with importing and installing
- changes dial timezone prop to date prop where a custom date can be provided
- updates tests to work with this new prop

## ⛳️ Testing

- ran yarn test and build locally
